### PR TITLE
Add extracted scripts and configuration to enable scrutinizer configs to be streamlined.

### DIFF
--- a/install_firefox.sh
+++ b/install_firefox.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ ! -f ~/build/vendor/firefox_28.0+build2-0ubuntu2_amd64.deb ]; then
+  wget "http://security.ubuntu.com/ubuntu/pool/main/f/firefox/firefox_28.0+build2-0ubuntu2_amd64.deb" -O ~/build/vendor/firefox_28.0+build2-0ubuntu2_amd64.deb
+fi
+sudo dpkg -i ~/build/vendor/firefox_28.0+build2-0ubuntu2_amd64.deb

--- a/install_mailcatcher.sh
+++ b/install_mailcatcher.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Push mailcatcher php ini config
-echo 'sendmail_path = '$(pwd)$'/bin/catchmail\nsmtp_port = 1025' | tee ~/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
+printf "sendmail_path = %s/bin/catchmail\nsmtp_port = 1025\n" "$(pwd)" >> "$HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini"
 # Install mailcatcher gem into bin/, caching gem install into .gems
 mkdir bin .gems
 gem install mailcatcher -v '~> 0.6.1' --no-rdoc --no-ri -i '.gems' -n 'bin'

--- a/install_mailcatcher.sh
+++ b/install_mailcatcher.sh
@@ -5,4 +5,4 @@ printf "sendmail_path = %s/bin/catchmail\nsmtp_port = 1025\n" "$(pwd)" >> "$HOME
 mkdir bin .gems
 gem install mailcatcher -v '~> 0.6.1' --no-rdoc --no-ri -i '.gems' -n 'bin'
 # Run mailcatcher
-bin/mailcatcher
+GEM_PATH="$GEM_PATH:$(pwd)/.gems/" bin/mailcatcher

--- a/install_mailcatcher.sh
+++ b/install_mailcatcher.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Push mailcatcher php ini config
+echo 'sendmail_path = '$(pwd)$'/bin/catchmail\nsmtp_port = 1025' | tee ~/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
+# Install mailcatcher gem into bin/, caching gem install into .gems
+mkdir bin .gems
+gem install mailcatcher -v '~> 0.6.1' --no-rdoc --no-ri -i '.gems' -n 'bin'
+# Run mailcatcher
+bin/mailcatcher

--- a/magento_cachebuster_apache.conf
+++ b/magento_cachebuster_apache.conf
@@ -1,0 +1,7 @@
+<IfModule mod_rewrite.c>
+    ############################################
+    ## rewrite files for magento cachebuster
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(.+)\.(\d+)\.(js|css|png|jpeg|jpg|gif)$ $1.$3 [L]
+</IfModule>

--- a/magento_local.xml
+++ b/magento_local.xml
@@ -1,0 +1,77 @@
+<config>
+    <global>
+        <environment><![CDATA[test]]></environment>
+        <install>
+            <date><![CDATA[Thu, 01 Jul 2010 10:29:20 +0000]]></date>
+        </install>
+        <crypt>
+            <key><![CDATA[{{crypt_key}}]]></key>
+        </crypt>
+        <disable_local_modules>false</disable_local_modules>
+        <resources>
+            <db>
+                <table_prefix><![CDATA[]]></table_prefix>
+            </db>
+            <core_write>
+                <connection>
+                    <use>default_write</use>
+                </connection>
+            </core_write>
+            <core_read>
+                <connection>
+                    <use>default_read</use>
+                </connection>
+            </core_read>
+            <default_setup>
+                <connection>
+                    <host><![CDATA[localhost]]></host>
+                    <username><![CDATA[magento]]></username>
+                    <password><![CDATA[magento]]></password>
+                    <dbname><![CDATA[magentodb]]></dbname>
+                    <persistent><![CDATA[false]]></persistent><!-- Persistent DB connection true / false / empty=false -->
+                    <active>1</active>
+                </connection>
+            </default_setup>
+            <default_read>
+                <connection>
+                    <host><![CDATA[localhost]]></host>
+                    <username><![CDATA[magento]]></username>
+                    <password><![CDATA[magento]]></password>
+                    <dbname><![CDATA[magentodb]]></dbname>
+                    <type><![CDATA[pdo_mysql]]></type>
+                    <persistent><![CDATA[false]]></persistent><!-- Persistent DB connection true / false / empty=false -->
+                    <active>1</active>
+                </connection>
+            </default_read>
+            <default_write>
+                <connection>
+                    <host><![CDATA[localhost]]></host>
+                    <username><![CDATA[magento]]></username>
+                    <password><![CDATA[magento]]></password>
+                    <dbname><![CDATA[magentodb]]></dbname>
+                    <type><![CDATA[pdo_mysql]]></type>
+                    <persistent><![CDATA[false]]></persistent><!-- Persistent DB connection true / false / empty=false -->
+                    <active>1</active>
+                </connection>
+            </default_write>
+        </resources>
+        <session_save><![CDATA[db]]></session_save>
+        <session_cache_limiter><![CDATA[nocache]]></session_cache_limiter><!-- see http://php.net/manual/en/function.session-cache-limiter.php#82174 for possible values -->
+        <cache>
+            <backend></backend><!-- apc / memcached / xcache / Cm_Cache_Backend_Redis empty=file -->
+        </cache>
+
+        <full_page_cache>
+            <backend></backend><!-- apc / memcached / xcache / Cm_Cache_Backend_Redis empty=file -->
+        </full_page_cache>
+    </global>
+    <admin>
+        <routers>
+            <adminhtml>
+                <args>
+                    <frontName><![CDATA[admin]]></frontName>
+                </args>
+            </adminhtml>
+        </routers>
+    </admin>
+</config>

--- a/run_behat_firefox_magento.sh
+++ b/run_behat_firefox_magento.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+myDIR="$(readlink -f "$(dirname "$0")")"
+
+mkdir -p ~/artifacts
+seleniumLog="$HOME/artifacts/selenium.log"
+firefoxLog="$HOME/artifacts/firefox.log"
+
+SELENIUM_MAJOR="2.45"
+SELENIUM_MINOR="0"
+SELENIUM_VERSION="${SELENIUM_MAJOR}.$SELENIUM_MINOR"
+
+SELENIUM_FILE="$myDIR/../bin/selenium-server-standalone-${SELENIUM_VERSION}.jar"
+test -f ./bin/selenium-server-standalone-$SELENIUM_VERSION.jar || wget "http://selenium-release.storage.googleapis.com/$SELENIUM_MAJOR/selenium-server-standalone-${SELENIUM_VERSION}.jar" -O ./bin/selenium-server-standalone-${SELENIUM_VERSION}.jar
+
+function fixHostsFileForSelenium() {
+    head -n1 /etc/hosts | grep -e '^127.0.0.1\s*localhost' >/dev/null || (
+        sudo cp /etc/hosts /etc/hosts.bak
+        echo "updating hosts.."
+        echo "127.0.0.1   localhost # required as fqdn for selenium not to fail" | sudo tee /etc/hosts
+        cat /etc/hosts.bak | sudo tee -a /etc/hosts
+    )
+}
+
+function prepSeleniumLauncher() {
+  echo '#!/bin/sh' > ~/runSelenium.sh
+  echo "cd '$myDIR'" >> ~/runSelenium.sh
+  echo "export NSPR_LOG_MODULES=all:3" >> ~/runSelenium.sh
+  echo "java -jar '$SELENIUM_FILE' -Dwebdriver.firefox.logfile='$firefoxLog' >'$seleniumLog' 2>&1 &" >> ~/runSelenium.sh
+  echo 'echo -n "$!" > /tmp/selenium.pid' >> ~/runSelenium.sh
+  echo 'wait' >> ~/runSelenium.sh
+  chmod +x ~/runSelenium.sh
+}
+
+function runSelenium() {
+  if test -z "$DISPLAY" ; then
+      xvfb-run ~/runSelenium.sh 2>/dev/null &
+  else
+      ~/runSelenium.sh &
+  fi
+
+  sleep 5
+  seleniumPID=$(cat '/tmp/selenium.pid')
+  echo "seleniumPID: $seleniumPID"
+
+  while ps -p "$seleniumPID" > /dev/null && ! ( cat "$seleniumLog" | grep 'INFO - Started org.openqa.jetty.jetty.Server' > /dev/null ) ; do
+      echo "waiting for selenium to start"
+      sleep 1
+  done
+
+  ps -p "$seleniumPID" >/dev/null || exit 1
+}
+
+function runBehat() {
+  echo "===== running behat ====="
+  pushd "$myDIR/.."
+  php -d 'xdebug.max_nesting_level=1000' bin/behat "$@"
+  local RETSTATUS="$?"
+  popd
+  return "$RETSTATUS"
+}
+
+function cleanMagentoLogs() {
+    rm -f "$firefoxLog"
+    rm -f "$seleniumLog"
+    rm -f "$myDIR/../public/var/log/exception.log"
+    rm -f "$myDIR/../public/var/log/system.log"
+}
+function copyMagentoLogsToArtifacts() {
+    mkdir -p "$HOME/artifacts/magento"
+    rm -f "$HOME/artifacts/magento/exception.log"
+    rm -f "$HOME/artifacts/magento/system.log"
+    test -f "$myDIR/../public/var/log/exception.log" && cp "$myDIR/../public/var/log/exception.log" "$HOME/artifacts/magento/"
+    test -f "$myDIR/../public/var/log/system.log" && cp "$myDIR/../public/var/log/system.log" "$HOME/artifacts/magento/"
+}
+
+function grepJsErrors() {
+    cat "$firefoxLog" | grep -v 'st.magentoiframechild.js\|html5player.js\|html5player-new.js\|gc is not defined' | grep 'JavaScript error:'
+    return $?
+}
+
+fixHostsFileForSelenium
+prepSeleniumLauncher
+cleanMagentoLogs
+runSelenium
+runBehat "$@"
+RETSTATUS="$?"
+copyMagentoLogsToArtifacts
+
+kill "$seleniumPID"
+sleep 3 && ( ps -p "$seleniumPID" >/dev/null && kill -9 "$seleniumPID" )
+
+if test -f "$firefoxLog" ; then
+#    if cat "$firefoxLog" | grep 'HTTP/1.1 404 Not Found' >/dev/null ; then
+#        cat <<'EOF'
+#    there are resources requested that returned 404. this is a
+#    particular problem in magento as it actually loads the whole
+#    magento framework for every non-existant file requested.
+#
+#    failed the build
+#EOF
+#        exit 1
+#    fi
+    if grepJsErrors >/dev/null ; then
+        echo 'There are javascript errors on the tests(failing the build):'
+        grepJsErrors
+        exit 1
+    fi
+fi
+
+exit "$RETSTATUS"


### PR DESCRIPTION
Scripts to:
- Install a specific version of firefox known to work with selenium (v28)
- Install and run mailcatcher to catch any emails generated in the tests
- Run behat via selenium, configured to use firefox as the browser

Configurations to:
- Bypass caching for assets in magento by rewriting css/js/image urls
- Have a dummy magento local.xml configuration that connects to localhost for the database after the magento_assets.sh script has been called.

To be used in concert with https://github.com/inviqa/hem-seed-magento/issues/35
